### PR TITLE
Features to specify monitoring,instance_type,ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Example `config.yaml`:
 
 ```bash
 cattle-aws:
-   request_spot_instances: # If you want to request spot instances. Set to true/false/empty
-   spot_price: # The spot instance price you want to bid. Ex. "0.75"
+   request_spot_instances: false
+   spot_price:
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name: "rancher-controlplane-role"
    iam_instance_profile_worker: # specify if overlap_cp_etcd_worker is false and existing_vpc is true
@@ -54,8 +55,10 @@ cattle-aws:
    vpc_id: "vpc-1abcdgggga72a691a"
    subnet_id: "subnet-1f98d368767ge1e71"
    security_group_name: "rancher-nodes"
-   os: "ubuntu"
-   instance_type: "t2.medium"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "true"
    overlap_node_pool:
       hostname_prefix: "cattle-aws-cluster"
@@ -74,8 +77,9 @@ Example `config.yaml`:
 
 ```bash
 cattle-aws:
-   request_spot_instances: # If you want to request spot instances. Set to true/false/empty
-   spot_price: # The spot instance price you want to bid. Ex. "0.75"
+   request_spot_instances: false
+   spot_price:
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name: "rancher-controlplane-role"
    iam_instance_profile_worker: “rancher-worker-role”
@@ -89,8 +93,10 @@ cattle-aws:
    vpc_id: "vpc-1abcdgggga72a691a"
    subnet_id: "subnet-1f98d368767ge1e71"
    security_group_name: "rancher-nodes"
-   os: "ubuntu"
-   instance_type: "t2.medium"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "ubuntu" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "false"
    overlap_node_pool:
       hostname_prefix:
@@ -109,8 +115,9 @@ Example `config.yaml`:
 
 ```bash
 cattle-aws:
-   request_spot_instances: # If you want to request spot instances. Set to true/false/empty
-   spot_price: # The spot instance price you want to bid. Ex. "0.75"
+   request_spot_instances: false
+   spot_price:
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name: "rancher-controlplane-role"
    iam_instance_profile_worker: # specify if overlap_cp_etcd_worker is false and existing_vpc is true
@@ -124,8 +131,10 @@ cattle-aws:
    vpc_id:
    subnet_id:
    security_group_name:
-   os: "ubuntu"
-   instance_type: "t2.medium"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "ubuntu" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "true"
    overlap_node_pool:
       hostname_prefix: "cattle-aws-cluster"
@@ -144,8 +153,9 @@ Example `config.yaml`:
 
 ```bash
 cattle-aws:
-   request_spot_instances: # If you want to request spot instances. Set to true/false/empty
-   spot_price: # The spot instance price you want to bid. Ex. "0.75"
+   request_spot_instances: false
+   spot_price:
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name: "rancher-controlplane-role"
    iam_instance_profile_worker: # specify if overlap_cp_etcd_worker is false and existing_vpc is true
@@ -159,10 +169,10 @@ cattle-aws:
    vpc_id:
    subnet_id:
    security_group_name:
-   os: "ubuntu"
-   instance_type: "t2.medium"
-   aws_secret_access_key:
-   aws_default_region: "eu-central-1"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "ubuntu" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "false"
    overlap_node_pool:
       hostname_prefix:
@@ -177,14 +187,13 @@ cattle-aws:
 
 ## Cattle AWS Deployment
 
-1. Donwload the latest binary based on your platform from here - https://github.com/kubernauts/tk8/releases
+1. Download the latest binary based on your platform from here - https://github.com/kubernauts/tk8/releases
 2. Set environment variables.
 3. Use a `config.yaml` from the above example.
 4. Run `tk8 cluster install cattle-aws`.
 
 ## Field Reference:
-
-* `request_spot_instances`: If you want to use spot instances for the cluster. Possible values: `true`,`false`. 
+* `request_spot_instances`: If you want to use spot instances for the cluster. Possible values: `true`,`false`. DO NOT keep this empty. Set it to false if spot instances are not required.
 
 * `spot_price`: The spot instance bidding price. For example: "0.75". Specify this along with `request_spot_instances` to use spot instances for the cluster.
 
@@ -216,7 +225,9 @@ cattle-aws:
 
 * `os`: (Mandatory) Operating System. The operating system you want to use for instances.
 
-* `instance_type`: (Mandatory) Instance type. The instance type which should be used to provision instances via Rancher.
+* `controlplane_instance_type`: (Mandatory) Instance type for controlplane nodes. The instance type which should be used to provision controlplane nodes via Rancher. Note that in case of overlapped controlplane, etcd and worker, this field will be used. `worker_instance_type` will only be used in case of non-overlapped node pools for separate workers.
+
+* `worker_instance_type`: (Optional) Instance type for worker nodes. This field should be specified when you want separate controlplane and worker node pools.
 
 * `overlap_cp_etcd_worker`: (Mandatory) If the cluster going to be an overlapped one. This means all instances will have the roles: Control Plane, Etcd, and Worker. This is similar to checkmark all the options via Rancher GUI while setting up node pools. The possible values for this field are boolean values: `true` and `false`.
 
@@ -237,8 +248,11 @@ cattle-aws:
     * `hostname_prefix`: (Required). This field is required to be set if you want to create an overlapped node pool. The hostname prefix’s value can be any `string`.
 
     * `quantity`: (Required). This field is required to be set if you want to create an overlapped node pool. The possible value for this field is of `numeric` type. 	
-    
-    
+
+* `cloudwatch_monitoring`: (Mandatory). This is field is required to be set. This field determines if cloudwatch monitoring should be enabled for the instances. The field type is `boolean` and the possible values are `true` and `false`. Please don't keep it empty.
+
+* `ami_id`: (Optional). Set this field if you want to use a specific AMI ID for creating instances in the cluster. It normally makes sense to keep `os` field empty while using this.
+
 ## Spot Instance Usage Caveats:
 While the use of spot instances is possible, TK8 uses the following conventions on where the spot instances will be used if `request_spot_instances` and `spot_price` are set:
 

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -26,7 +26,7 @@ type CattleAWSConfig struct {
 	SubnetID                 string
 	SecurityGroupName        string
 	OS                       string
-	InstanceType             string
+	WorkerInstanceType       string
 	OverlapCpEtcdWorker      bool
 	OverlapHostnamePrefix    string
 	OverlapQuantity          string
@@ -39,6 +39,9 @@ type CattleAWSConfig struct {
 	RootDiskSize             string
 	RequestSpotInstances     bool
 	SpotPrice                string
+	ControlPlaneInstanceType string
+	AmiID                    string
+	CloudwatchMonitoring     bool
 }
 
 func GetCattleAWSConfig() CattleAWSConfig {
@@ -55,7 +58,7 @@ func GetCattleAWSConfig() CattleAWSConfig {
 		SubnetID:                 viper.GetString("cattle-aws.subnet_id"),
 		SecurityGroupName:        viper.GetString("cattle-aws.security_group_name"),
 		OS:                       viper.GetString("cattle-aws.os"),
-		InstanceType:             viper.GetString("cattle-aws.instance_type"),
+		WorkerInstanceType:       viper.GetString("cattle-aws.worker_instance_type"),
 		OverlapCpEtcdWorker:      viper.GetBool("cattle-aws.overlap_cp_etcd_worker"),
 		OverlapHostnamePrefix:    viper.GetString("cattle-aws.overlap_node_pool.hostname_prefix"),
 		OverlapQuantity:          viper.GetString("cattle-aws.overlap_node_pool.quantity"),
@@ -68,6 +71,9 @@ func GetCattleAWSConfig() CattleAWSConfig {
 		RootDiskSize:             viper.GetString("cattle-aws.root_disk_size"),
 		RequestSpotInstances:     viper.GetBool("cattle-aws.request_spot_instances"),
 		SpotPrice:                viper.GetString("cattle-aws.spot_price"),
+		ControlPlaneInstanceType: viper.GetString("cattle-aws.controlplane_instance_type"),
+		AmiID:                    viper.GetString("cattle-aws.ami_id"),
+		CloudwatchMonitoring:     viper.GetBool("cattle-aws.cloudwatch_monitoring"),
 	}
 }
 

--- a/internal/templates/variables.go
+++ b/internal/templates/variables.go
@@ -1,6 +1,24 @@
 package templates
 
 var VariablesCattleAWS = `
+variable "cloudwatch_monitoring" {
+  default     = "{{.CloudwatchMonitoring}}"
+  description = "Enable/Disable cloudwatch monitoring"
+  type        = "string"
+}
+
+variable "ami_id" {
+  default     = "{{.AmiID}}"
+  description = "AMI ID for instances"
+  type        = "string"
+}
+
+variable "controlplane_instance_type" {
+  default     = "{{.ControlPlaneInstanceType}}"
+  description = "Control plane instance type"
+  type        = "string"
+}
+
 variable "request_spot_instances" {
   default     = "{{.RequestSpotInstances}}"
   description = "Request spot instances for the node template"
@@ -94,8 +112,8 @@ variable "os" {
   type        = "string"
 }
 
-variable "instance_type" {
-  default     = "{{.InstanceType}}"
+variable "worker_instance_type" {
+  default     = "{{.WorkerInstanceType}}"
   description = "Instance type"
   type        = "string"
 }

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,8 @@ module "cattle-aws" {
   subnet_id                                  = var.subnet_id
   security_group_name                        = var.security_group_name
   os                                         = var.os
-  instance_type                              = var.instance_type
+  controlplane_instance_type                 = var.controlplane_instance_type
+  worker_instance_type                       = var.worker_instance_type
   overlap_cp_etcd_worker                     = var.overlap_cp_etcd_worker
   no_overlap_nodepool_master_quantity        = var.no_overlap_nodepool_master_quantity
   no_overlap_nodepool_worker_quantity        = var.no_overlap_nodepool_worker_quantity
@@ -29,5 +30,7 @@ module "cattle-aws" {
   root_disk_size                             = var.root_disk_size
   request_spot_instances                     = var.request_spot_instances
   spot_price                                 = var.spot_price
+  ami_id                                     = var.ami_id
+  cloudwatch_monitoring                      = var.cloudwatch_monitoring
 }
 

--- a/modules/cattle-aws/variables.tf
+++ b/modules/cattle-aws/variables.tf
@@ -51,7 +51,7 @@ variable "os" {
   type        = "string"
 }
 
-variable "instance_type" {
+variable "worker_instance_type" {
   description = "Instance type"
   type        = "string"
 }
@@ -157,4 +157,22 @@ variable "spot_price" {
   default     = ""
   description = "Spot instances price for node template"
   type        = string
+}
+
+variable "controlplane_instance_type" {
+  default     = ""
+  description = "Controlplane instance type"
+  type        = "string"
+}
+
+variable "ami_id" {
+  default     = ""
+  description = "AMI id for the instance"
+  type        = "string"
+}
+
+variable "cloudwatch_monitoring" {
+  default     = ""
+  description = "Enable/Disable cloudwatch monitoring for instances"
+  type        = "string"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,36 @@
+
+variable "cloudwatch_monitoring" {
+  default     = ""
+  description = "Enable/Disable cloudwatch monitoring for instances"
+  type        = string
+}
+
+variable "ami_id" {
+  default     = ""
+  description = "AMI id for the instance"
+  type        = string
+}
+
+variable "controlplane_instance_type" {
+  default     = ""
+  description = "Controlplane instance type"
+  type        = string
+}
+
 variable "request_spot_instances" {
-  default     = false
+  default     = ""
   description = "Request spot instances for the node template"
   type        = string
 }
 
 variable "spot_price" {
   default     = ""
-  description = "Spot instances price for node template"
+  description = "Spot instances price for the node template"
   type        = string
 }
 
 variable "root_disk_size" {
-  default     = "20"
+  default     = ""
   description = "Root disk size for instances in GB"
   type        = string
 }
@@ -29,7 +48,7 @@ variable "iam_instance_profile_name" {
 }
 
 variable "rancher_api_url" {
-  default     = "https://rancher.kubernauts.de/v3"
+  default     = ""
   description = "Rancher API URL"
   type        = string
 }
@@ -43,19 +62,19 @@ variable "rancher_secret_key" {
 }
 
 variable "rancher_cluster_name" {
-  default     = "cattle-aws-demo"
+  default     = ""
   description = "Rancher cluster name"
   type        = string
 }
 
 variable "rke_network_plugin" {
-  default     = "canal"
+  default     = ""
   description = "Network plugin for cluster"
   type        = string
 }
 
 variable "region" {
-  default     = "eu-central-1"
+  default     = ""
   description = "AWS region"
   type        = string
 }
@@ -85,25 +104,25 @@ variable "security_group_name" {
 }
 
 variable "os" {
-  default     = "ubuntu"
+  default     = ""
   description = "ami id - frankfurt"
   type        = string
 }
 
-variable "instance_type" {
-  default     = "t2.medium"
+variable "worker_instance_type" {
+  default     = ""
   description = "Instance type"
   type        = string
 }
 
 variable "overlap_cp_etcd_worker" {
-  default     = true
+  default     = false
   description = "Overlapping planes for node template"
   type        = string
 }
 
 variable "overlap_node_pool_hostname_prefix" {
-  default     = "cattle-aws-demo"
+  default     = ""
   description = "Hostname prefix for overlapped node pools"
   type        = string
 }
@@ -133,7 +152,7 @@ variable "no_overlap_nodepool_worker_quantity" {
 }
 
 variable "overlap_node_pool_quantity" {
-  default     = "1"
+  default     = ""
   description = "Node pool quantity for overlap planes"
   type        = string
 }
@@ -149,4 +168,3 @@ variable "AWS_SECRET_ACCESS_KEY" {
 variable "AWS_DEFAULT_REGION" {
   description = "AWS default region"
 }
-


### PR DESCRIPTION
Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

Fixes: 
1. #1 - Add support for spot instances
2. #2 - Specify different instance types for controlplane and worker nodes
3. #3 - User can now specify AMI id directly instead of specifying os `os`
4. #4 - Added cloudwatch monitoring option.